### PR TITLE
thunar: Disable automounting of removable storage

### DIFF
--- a/overrides/thunar-volman.xml
+++ b/overrides/thunar-volman.xml
@@ -2,13 +2,13 @@
 
 <channel name="thunar-volman" version="1.0">
   <property name="automount-drives" type="empty">
-    <property name="enabled" type="bool" value="true"/>
+    <property name="enabled" type="bool" value="false"/>
   </property>
   <property name="automount-media" type="empty">
-    <property name="enabled" type="bool" value="true"/>
+    <property name="enabled" type="bool" value="false"/>
   </property>
   <property name="autobrowse" type="empty">
-    <property name="enabled" type="bool" value="true"/>
+    <property name="enabled" type="bool" value="false"/>
   </property>
   <property name="autoplay-video-cds" type="empty">
     <property name="enabled" type="bool" value="true"/>


### PR DESCRIPTION
This is in alignment with (most of) the other desktops, and also fixes the issue of it breaking the installer when BTRFS is chosen.

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
