### PR TITLE
lightdm: Set autologin-session for auto login to work

### DIFF
--- a/lightdm/xfce_config.conf
+++ b/lightdm/xfce_config.conf
@@ -117,6 +117,7 @@ session-wrapper=/usr/bin/lightdm-wrapper
 #session-setup-script=
 #session-cleanup-script=
 #autologin-guest=false
+autologin-session=xfce
 autologin-user=live
 autologin-user-timeout=0
 #autologin-in-background=false


### PR DESCRIPTION
Unlike other editions it seems we need to set the autologin-session for auto login to work on XFCE.