### PR TITLE
Add slick-greeter defaults & remove lightdm-gtk-greeter config

### DIFF
--- a/lightdm/10_xfce.conf
+++ b/lightdm/10_xfce.conf
@@ -1,4 +1,0 @@
-[greeter]
-background=/usr/share/backgrounds/solus/Excl_Vintage_Bicycles.jpg
-theme-name=Qogir-Dark
-icon-theme-name=Papirus

--- a/lightdm/meson.build
+++ b/lightdm/meson.build
@@ -1,12 +1,6 @@
-lightdm_gtk_dir = join_paths(path_datadir, 'lightdm', 'lightdm-gtk-greeter.conf.d')
 lightdm_dir = join_paths(path_datadir, 'lightdm', 'lightdm.conf.d')
 
 install_data(
     'xfce_config.conf',
     install_dir: lightdm_dir,
-)
-
-install_data(
-    '10_xfce.conf',
-    install_dir: lightdm_gtk_dir,
 )

--- a/meson.build
+++ b/meson.build
@@ -9,11 +9,15 @@ project(
   ],
 )
 
+meson.add_install_script('meson_post_install.sh')
+
 path_prefix = get_option('prefix')
 path_datadir = join_paths(path_prefix, get_option('datadir'))
+path_schemadir = join_paths(path_datadir, 'glib-2.0', 'schemas')
 
 subdir('lightdm')
 subdir('overrides')
+subdir('schemas')
 
 report = [
   '    Build configuration:',

--- a/meson_post_install.sh
+++ b/meson_post_install.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if [ -z $DESTDIR ]; then
+	PREFIX=${MESON_INSTALL_PREFIX:-/usr}
+	glib-compile-schemas "$PREFIX/share/glib-2.0/schemas"
+fi

--- a/schemas/meson.build
+++ b/schemas/meson.build
@@ -1,0 +1,12 @@
+xfce_schemas = [
+    'x.dm.slick-greeter.override',
+]
+
+custom_target('30_xfce_settings.gschema.override',
+    output: '30_xfce_settings.gschema.override',
+    capture: true,
+    input: xfce_schemas,
+    command: ['cat', '@INPUT@'],
+    install: true,
+    install_dir: path_schemadir,
+)

--- a/schemas/x.dm.slick-greeter.override
+++ b/schemas/x.dm.slick-greeter.override
@@ -1,0 +1,4 @@
+[x.dm.slick-greeter]
+background='/usr/share/backgrounds/solus/Excl_Vintage_Bicycles.jpg'
+icon-theme-name='Papirus'
+theme-name='Qogir-Dark'


### PR DESCRIPTION
slick-greeter requires gschemas overrides for vendor defaults.
The lightdm-gtk-greeter config file doesn't do anything.