### PR TITLE
mimeapps.list: Switch from Evince to XReader

### DIFF
--- a/xfce-mimeapps.list
+++ b/xfce-mimeapps.list
@@ -199,23 +199,23 @@ x-content/video-vcd=org.xfce.Parole.desktop
 x-scheme-handler/mmsh=org.xfce.Parole.desktop
 x-scheme-handler/mms=org.xfce.Parole.desktop
 
-# PDF Viewer (Evince)
-application/pdf=org.gnome.Evince.desktop
-application/postscript=org.gnome.Evince.desktop
-application/x-bzdvi=org.gnome.Evince.desktop
-application/x-bzpdf=org.gnome.Evince.desktop
-application/x-bzpostscript=org.gnome.Evince.desktop
-application/x-cb7=org.gnome.Evince.desktop
-application/x-cbr=org.gnome.Evince.desktop
-application/x-cbz=org.gnome.Evince.desktop
-application/x-dvi=org.gnome.Evince.desktop
-application/x-gzdvi=org.gnome.Evince.desktop
-application/x-gzpdf=org.gnome.Evince.desktop
-application/x-gzpostscript=org.gnome.Evince.desktop
-image/vnd.djvu=org.gnome.Evince.desktop
-image/x-bzeps=org.gnome.Evince.desktop
-image/x-eps=org.gnome.Evince.desktop
-image/x-gzeps=org.gnome.Evince.desktop
+# PDF Viewer (XReader)
+application/pdf=xreader.desktop
+application/postscript=xreader.desktop
+application/x-bzdvi=xreader.desktop
+application/x-bzpdf=xreader.desktop
+application/x-bzpostscript=xreader.desktop
+application/x-cb7=xreader.desktop
+application/x-cbr=xreader.desktop
+application/x-cbz=xreader.desktop
+application/x-dvi=xreader.desktop
+application/x-gzdvi=xreader.desktop
+application/x-gzpdf=xreader.desktop
+application/x-gzpostscript=xreader.desktop
+image/vnd.djvu=xreader.desktop
+image/x-bzeps=xreader.desktop
+image/x-eps=xreader.desktop
+image/x-gzeps=xreader.desktop
 
 # Text Editor (Mousepad)
 application/javascript=org.xfce.mousepad.desktop


### PR DESCRIPTION
Switch the default PDF reader from Evince to XReader

Ref https://github.com/getsolus/xfce4-desktop-branding/issues/9

Signed-off-by: Evan Maddock <maddock.evan@vivaldi.net>
